### PR TITLE
Sort IPs in Usage Overview table

### DIFF
--- a/msp/msp/doctype/ip_network_reserved_range/ip_network_reserved_range.json
+++ b/msp/msp/doctype/ip_network_reserved_range/ip_network_reserved_range.json
@@ -9,6 +9,7 @@
   "start",
   "end",
   "type",
+  "protocol",
   "description"
  ],
  "fields": [
@@ -35,12 +36,19 @@
    "fieldname": "description",
    "fieldtype": "Text Editor",
    "label": "Description"
+  },
+  {
+   "default": "IPv4",
+   "fieldname": "protocol",
+   "fieldtype": "Select",
+   "label": "Protocol",
+   "options": "IPv4\nIPv6"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-08-17 13:44:07.476976",
+ "modified": "2022-09-05 09:57:47.527108",
  "modified_by": "Administrator",
  "module": "MSP",
  "name": "IP Network Reserved Range",


### PR DESCRIPTION
Closes #27 

Sort IPs in Usage Overview table. Sorting methods supports both IPv4 and IPv6.

✅ IPs sorted properly

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/63541019/188402482-160d2d8c-e6f6-4433-883b-606ab156b12b.png">
