### PR TITLE
Location Doctype: Add link to IT Objects List with filter

### DIFF
--- a/msp/hooks.py
+++ b/msp/hooks.py
@@ -135,3 +135,6 @@ doc_events = {
 # 	"Task": "msp.task.get_dashboard_data"
 # }
 
+override_doctype_class = {
+    "Location": "msp.overrides.location.CustomLocation.CustomLocation"
+}

--- a/msp/hooks.py
+++ b/msp/hooks.py
@@ -39,6 +39,8 @@ jenv = {
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
 
+doctype_js = {"Location" : "public/js/location.js"}
+
 # Home Pages
 # ----------
 

--- a/msp/overrides/location/CustomLocation.py
+++ b/msp/overrides/location/CustomLocation.py
@@ -1,0 +1,18 @@
+import frappe
+from erpnext.assets.doctype.location.location import Location
+
+class CustomLocation(Location):
+    @frappe.whitelist()
+    def get_all_child_locations_from_location(self):
+        parent_location_name = self.name
+        locations_to_filter = []
+        return self.search_child_locations(locations_to_filter, parent_location_name)
+
+    def search_child_locations(self, locations_to_filter, parent_location_name):
+        locations_to_filter.append(parent_location_name)
+        child_locations = frappe.db.get_list('Location', {'parent_location': parent_location_name}, ['name'])
+        if child_locations:
+            for child_location in child_locations:
+                self.search_child_locations(locations_to_filter, child_location['name'])
+
+        return locations_to_filter

--- a/msp/public/js/location.js
+++ b/msp/public/js/location.js
@@ -1,7 +1,10 @@
 frappe.ui.form.on('Location', {
     refresh(frm) {
         frm.add_custom_button('Show IT Objects in Location', () => {
-            frappe.set_route('List', 'IT Object', { location_full_path: ['like', `%${frm.doc.location_name}%`] })
+            frm.call('get_all_child_locations_from_location',{})
+                .then((response) => {
+                    frappe.set_route('List', 'IT Object', { location: ['in', `${response.message.toString()}`] })
+                })
         })
     }
 });

--- a/msp/public/js/location.js
+++ b/msp/public/js/location.js
@@ -1,0 +1,7 @@
+frappe.ui.form.on('Location', {
+    refresh(frm) {
+        frm.add_custom_button('Show IT Objects in Location', () => {
+            frappe.set_route('List', 'IT Object', { location_full_path: ['like', `%${frm.doc.location_name}%`] })
+        })
+    }
+});


### PR DESCRIPTION
Closes #33 

Add a custom button which displays the IT Objects List filtered by the location and its child locations.